### PR TITLE
Android 37 & robolectric 4.17 beta

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         // minSdkVersion <= targetSdkVersion <= compileSdk
         minSdkVersion 30
         targetSdkVersion 35
-        compileSdk = 36
+        compileSdk = 37
 
         applicationId "eu.monniot.resync"
         versionCode 1
@@ -108,7 +108,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0'
-    testImplementation 'org.robolectric:robolectric:4.16.1'
+    testImplementation 'org.robolectric:robolectric:4.17-beta-2'
 
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'


### PR DESCRIPTION
Use the beta version of robolectric to unlock upgrade to android 37