### PR TITLE
Add a cancellation path to the download flow

### DIFF
--- a/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
@@ -26,7 +26,9 @@ import eu.monniot.resync.downloader.*
 import eu.monniot.resync.makeEpub
 import eu.monniot.resync.ui.KeepScreenOn
 import eu.monniot.resync.ui.ReSyncTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import java.lang.NumberFormatException
 
@@ -63,7 +65,10 @@ fun DownloadScreen(
     // We can't really do background processing either as we are using a WebView.
     KeepScreenOn()
 
+    var downloadJob by remember { mutableStateOf<Job?>(null) }
+
     LaunchedEffect(key1 = storyId, key2 = chapterId) {
+        downloadJob = coroutineContext[Job]
         try {
             // wait for the driver to be attached to a running WebView
             driver.ready()
@@ -73,11 +78,20 @@ fun DownloadScreen(
             // Only call onDone if there was no error, otherwise let the user
             // choose when to close the app.
             onDone()
+        } catch (e: CancellationException) {
+            // Cancellation (see onCancel below) is not an error: don't render the Error
+            // screen, and don't call onDone() again - onCancel already does.
+            throw e
         } catch (e: Throwable) {
-            println("Error caught when downloading story")
-            e.printStackTrace()
+            Log.e(TAG, "Error caught when downloading story", e)
             setState(DownloadState.Error(e))
         }
+    }
+
+    val onCancel: () -> Unit = {
+        downloadJob?.cancel()
+        clearChapterCache(driver.storyCacheDir(storyId))
+        onDone()
     }
 
     Box {
@@ -117,11 +131,13 @@ fun DownloadScreen(
                 state.totalChapters,
                 state.driverType,
                 state.onUserConfirmation,
+                onCancel = onCancel,
             )
             is DownloadState.DownloadingRemainingChapters -> DownloadingRemainingChapters(
                 currentlyDownloading = state.currentlyDownloading,
                 totalToDownloads = state.totalToDownloads,
                 notice = state.notice,
+                onCancel = onCancel,
             )
             is DownloadState.Error -> DisplayDownloadError(
                 error = state.throwable,
@@ -488,6 +504,7 @@ fun ConfirmChapters(
     totalChapters: Int,
     driverType: DriverType,
     onUserConfirmation: (ChapterSelection) -> Unit,
+    onCancel: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -639,6 +656,7 @@ fun DownloadingRemainingChapters(
     currentlyDownloading: Int,
     totalToDownloads: Int,
     notice: String?,
+    onCancel: () -> Unit = {},
 ) {
     Column(
         verticalArrangement = Arrangement.Center,


### PR DESCRIPTION
Implements [redesign-04-cancellation-plumbing](docs/tickets/redesign-04-cancellation-plumbing.md).

Stacked on `redesign-00-dependency-and-theme` (PR #685, not yet merged) as part of the sequential Material 3 redesign series — please diff against that branch, not `main`.

## Summary

Adds a cancellation path to `DownloadScreen`'s download flow, per the resolved decision that cancelling unwinds the download and discards partial work:

- `DownloadScreen`'s `LaunchedEffect` now captures its `Job` (`downloadJob`) via `coroutineContext[Job]`.
- The catch block now rethrows `CancellationException` before the general `catch (e: Throwable)`, so cancelling never produces `DownloadState.Error`. Structured concurrency propagates cancellation into every suspend call in the chain (`CompletableDeferred.await()` for user chapter selection, the rate-limit retry `delay()` loop, the inter-chapter pacing delays, and `JsInterface.waitForHtml()` inside `Driver.readChapter`) with no cancellation flag threaded through `selectChaptersToDownload`.
- Added an `onCancel: () -> Unit` lambda in `DownloadScreen` that cancels `downloadJob`, calls `clearChapterCache(driver.storyCacheDir(storyId))`, and calls `onDone()` (same "leave this screen" semantics used on the success path — back to Search / `finish()` the deep-linked activity).
- `ConfirmChapters` and `DownloadingRemainingChapters` both gain an `onCancel: () -> Unit` parameter (defaulted to a no-op so existing `@Preview` call sites don't need updating). Neither renders it yet — this ticket is behavior-only, no UI; redesign-03 and redesign-05 wire the back arrow / close icon to it.
- Replaced the `println(...)` + `e.printStackTrace()` error logging with `Log.e(TAG, …)`.

`selectChaptersToDownload`'s signature is unchanged.

## Acceptance criteria

- [x] `DownloadScreen`'s `LaunchedEffect` rethrows `CancellationException` before the general `catch (e: Throwable)`; cancelling never produces `DownloadState.Error`.
- [x] `DownloadScreen` exposes an `onCancel` lambda that cancels the download job, calls `clearChapterCache(driver.storyCacheDir(storyId))`, and calls `onDone()`.
- [x] `ConfirmChapters` and `DownloadingRemainingChapters` both take an `onCancel: () -> Unit` parameter.
- [x] `println(...)` and `e.printStackTrace()` no longer appear in `DownloadScreen.kt`; the error path logs through `Log.e(TAG, …)`.
- [ ] Manual verification on a device or emulator — **not performed**. No `adb`/emulator is available in this environment (agent worktree, headless), so I could not physically trigger the flow. I instead traced the cancellation path carefully:
  - `downloadJob = coroutineContext[Job]` captures the `LaunchedEffect` coroutine's own `Job`.
  - `onCancel` calling `downloadJob?.cancel()` marks that job (and thus its whole call chain — `downloadLogic` → `selectChaptersToDownload` → `readWithRateLimit` → `Driver.readChapter`) for cancellation.
  - Every suspension point in that chain is a standard cancellable coroutine primitive: `CompletableDeferred.await()` (both the user's chapter-selection choice and `JsInterface.waitForHtml()` inside `Driver.readChapter`) and `delay()` (rate-limit backoff, inter-chapter pacing). Any of these throws `CancellationException` at the next suspension checkpoint after cancel.
  - That exception unwinds through `downloadLogic` back to the `LaunchedEffect`'s `catch (e: CancellationException) { throw e }`, which rethrows rather than falling into `catch (e: Throwable)` — so `DownloadState.Error` is never set and the composable's existing state (whatever it last rendered) is simply abandoned as the coroutine dies.
  - `onCancel` calls `clearChapterCache(driver.storyCacheDir(storyId))` synchronously (not gated on the cancelled job finishing) and then `onDone()`, which is the same callback the success path already relies on to leave the screen (`SearchStoryScreen.kt` sets `storySelected.value = false`; `DeepLinkActivity.kt` calls `finish()`).
  - One edge case worth flagging for a human to actually exercise on-device: `Job.cancel()` is asynchronous — it requests cancellation but doesn't wait for the job to stop — so there's a narrow window where `clearChapterCache` runs concurrently with an in-flight `withContext(ioDispatcher) { tmpChapterFile.writeText(html) }` inside `Driver.readChapter`. This matches the ticket's code sketch exactly and is very unlikely to matter in practice, but real-device testing is the only way to be sure nothing odd shows up (partial file, stale directory, etc.).
  - This item needs a human to check on a device/emulator; I did not fabricate a pass.
- [x] `./gradlew assembleDebug` and `./gradlew test` pass. In particular the existing `selectChaptersToDownload` unit tests (`SelectChaptersToDownloadTest`, 6 tests) still pass unchanged.

## Deviations

None from the ticket's proposed fix. I did not add a temporary debug cancel button for manual testing, since there's no device/emulator in this environment to exercise it with, and the ticket is explicit that this ticket "adds no UI" — didn't want to leave dead/unreachable debug UI in the diff for something I couldn't actually verify.