### PR TITLE
Rebuild the Search screen on M3 components

### DIFF
--- a/app/src/main/java/eu/monniot/resync/downloader/DriverType.kt
+++ b/app/src/main/java/eu/monniot/resync/downloader/DriverType.kt
@@ -8,4 +8,15 @@ enum class DriverType {
         ArchiveOfOurOwn -> "Archive of our Own"
         FanFictionNet -> "FanFiction.Net"
     }
+
+    /**
+     * Short label used in the Search screen's segmented button row, where
+     * [SingleChoiceSegmentedButtonRow] weights both segments equally and the full
+     * [websiteName] doesn't fit at `labelLarge`. Not used elsewhere -- [websiteName] remains
+     * the user-facing name on the Confirm screen and in DownloadScreen's error copy.
+     */
+    fun shortName() = when(this) {
+        ArchiveOfOurOwn -> "AO3"
+        FanFictionNet -> "FF.Net"
+    }
 }

--- a/app/src/main/java/eu/monniot/resync/ui/launcher/SearchStoryScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/launcher/SearchStoryScreen.kt
@@ -1,17 +1,27 @@
 package eu.monniot.resync.ui.launcher
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -70,6 +80,7 @@ fun isValidOptionalNumericId(text: String): Boolean = text.isBlank() || isValidN
 fun canSyncStory(storyId: String, chapterId: String): Boolean =
     isValidNumericId(storyId) && isValidOptionalNumericId(chapterId)
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StorySelectionView(
     storyId: MutableState<TextFieldValue>,
@@ -80,57 +91,81 @@ fun StorySelectionView(
     val storyIdText = storyId.value.text
     val chapterIdText = chapterId.value.text
 
-    Column(Modifier.padding(16.dp)) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(top = 8.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
+    ) {
         TextField(
             value = storyId.value,
             onValueChange = { storyId.value = it },
-            label = { Text("Story Id") },
+            label = { Text("Story ID") },
+            supportingText = { Text("e.g. 39200706") },
             isError = storyIdText.isNotEmpty() && !isValidNumericId(storyIdText),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         )
+
+        Spacer(Modifier.height(8.dp))
 
         TextField(
             value = chapterId.value,
             onValueChange = { chapterId.value = it },
-            label = { Text("Chapter Id (optional)") },
+            label = { Text("Chapter (optional)") },
+            supportingText = { Text("e.g. 4") },
             isError = !isValidOptionalNumericId(chapterIdText),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         )
 
-        Text("Provider", style = MaterialTheme.typography.subtitle2)
-        Column(Modifier.padding(bottom = 8.dp)) {
-            DriverType.values().forEach { driver ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .selectable(
-                            selected = driverType.value == driver,
-                            onClick = { driverType.value = driver }
-                        ),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    RadioButton(
-                        selected = driverType.value == driver,
-                        onClick = { driverType.value = driver }
-                    )
-                    Text(driver.websiteName())
-                }
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            "Provider",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            DriverType.entries.forEachIndexed { index, driver ->
+                SegmentedButton(
+                    selected = driverType.value == driver,
+                    onClick = { driverType.value = driver },
+                    shape = SegmentedButtonDefaults.itemShape(index, DriverType.entries.size),
+                    label = { Text(driver.shortName(), maxLines = 1) },
+                )
             }
         }
 
-        Text(
-            "Note that FF.Net has recently changed their Cloudflare protection plan" +
-                    " and as such, using that provider might crash the app. If that is the" +
-                    " case, then retrying won't help. Hopefully that is something we can fix.",
-            style = MaterialTheme.typography.caption
-        )
+        Spacer(Modifier.height(16.dp))
 
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            ),
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                "Note that FF.Net has recently changed their Cloudflare protection plan" +
+                        " and as such, using that provider might crash the app. If that is the" +
+                        " case, then retrying won't help. Hopefully that is something we can fix.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        // TODO(redesign-11): add a leading Icons.Rounded.Sync once the Material Symbols icon
+        // set lands (see docs/tickets/redesign-11-material-symbols-icons.md).
         Button(
             onClick = onClick,
             enabled = canSyncStory(storyIdText, chapterIdText),
-            modifier = Modifier.padding(top = 8.dp)
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Sync")
         }
@@ -141,6 +176,14 @@ fun StorySelectionView(
 @Composable
 fun SearchStoryScreenPreview() {
     ReSyncTheme {
+        SearchStoryScreen()
+    }
+}
+
+@Preview
+@Composable
+fun SearchStoryScreenDarkPreview() {
+    ReSyncTheme(darkTheme = true) {
         SearchStoryScreen()
     }
 }


### PR DESCRIPTION
Implements [docs/tickets/redesign-02-search-screen.md](docs/tickets/redesign-02-search-screen.md): rebuilds `StorySelectionView` in `SearchStoryScreen.kt` on M3 components per the Calm Reader v2 design.

## Summary

- Both fields are now M3 filled `TextField`s, full-width, with supporting text ("e.g. 39200706" / "e.g. 4") and labels "Story ID" / "Chapter (optional)".
- The "Provider" label is now `labelLarge`/`onSurfaceVariant` with 8dp below it.
- The radio-button provider picker is replaced by `SingleChoiceSegmentedButtonRow` + `SegmentedButton`, opted into `@ExperimentalMaterial3Api` at the composable level (same pattern as `LauncherScreen.kt`).
- The Cloudflare warning is now a `surfaceContainerHighest` `Card`, 12dp corners, 16dp internal padding; copy unchanged.
- The Sync button is full-width, bottom-anchored via a `weight(1f)` spacer, text-only (see below).
- Added a dark-theme `SearchStoryScreenDarkPreview`.
- `isValidNumericId`, `isValidOptionalNumericId`, `canSyncStory` are untouched (byte-identical).

## Segmented-button label approach

Added `DriverType.shortName()` (`"AO3"` / `"FF.Net"`) and used it **only** in the segmented row, rather than `websiteName()`. At a 360dp preview width the two equal-width segments are ~156dp each minus the check icon and padding — not enough room for "Archive of our Own" at `labelLarge` without ellipsizing. `websiteName()` is untouched and still used by `DownloadScreen`'s "From: …" copy (the Confirm Chapters screen from ticket 03 hasn't landed yet, so nothing there depends on it yet).

## Sync button icon

`Icons.Rounded.Sync` depends on ticket 11 (Material Symbols icons), which hasn't landed — the app has no `material-icons-extended` dependency yet. Shipped text-only per the ticket's explicit fallback, with a `TODO(redesign-11)` comment naming the ticket.

## Acceptance criteria

- [x] `SearchStoryScreen.kt` imports `androidx.compose.material3.*` and contains no `androidx.compose.material.*` import.
- [x] Both fields are M3 `TextField`s, full-width, labelled "Story ID" and "Chapter (optional)", with supporting text "e.g. 39200706" and "e.g. 4" respectively.
- [x] `RadioButton` no longer appears in the file; provider selection is `SingleChoiceSegmentedButtonRow` + `SegmentedButton`, and tapping a segment still sets `driverType.value`.
- [x] Neither segment label is truncated or ellipsized in `SearchStoryScreenPreview`; `shortName()` was added, `websiteName()` still exists and is still used by `DownloadScreen` (its Confirm-screen usage lands with ticket 03).
- [x] The Cloudflare warning renders inside a `surfaceContainerHighest` card with 12dp corners and 16dp internal padding; its copy is byte-identical to today's.
- [x] The Sync button is the last element in the column, full-width, and separated from the content above by a `weight(1f)` spacer.
- [x] `canSyncStory` / `isValidNumericId` / `isValidOptionalNumericId` are byte-identical to before this ticket, and `./gradlew test` passes.
- [x] `SearchStoryScreenPreview` renders without error; added a dark-theme variant.

## Stacking

This PR is stacked on `redesign-01-scaffold-and-navigation` (PR #687), which is itself stacked on `redesign-04-cancellation-plumbing` (PR #686) → `redesign-00-dependency-and-theme` (PR #685). None of those are merged yet. **Reviewers should diff against `redesign-01-scaffold-and-navigation`, not `main`.**