### PR TITLE
Rebuild the chapter-confirmation screen on M3 components

### DIFF
--- a/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
@@ -5,15 +5,29 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import android.webkit.WebView
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+// The rest of this file (ConfirmChapters) has been migrated to M3; FetchingFirstChapterView,
+// DownloadingRemainingChapters and DisplayDownloadError have not (separate tickets) and still
+// need a handful of M2 symbols (MaterialTheme.typography.h6/body2, the Float-based
+// CircularProgressIndicator overload) that have no direct M3 equivalent. Both packages declare
+// types with the same simple names (Text, MaterialTheme, ...), so the M2 ones used below are
+// imported explicitly under an alias instead of via `androidx.compose.material.*`, which would
+// otherwise shadow the M3 wildcard import for the whole file.
+import androidx.compose.material.CircularProgressIndicator as M2CircularProgressIndicator
+import androidx.compose.material.MaterialTheme as M2MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,6 +44,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
 import java.lang.NumberFormatException
 
 private const val TAG = "DownloadFic"
@@ -458,7 +473,7 @@ fun FetchingFirstChapterView(storyId: StoryId, chapterId: ChapterId) {
 
         Text(
             text = "Looking up Story",
-            style = MaterialTheme.typography.h6,
+            style = M2MaterialTheme.typography.h6,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         )
 
@@ -466,13 +481,13 @@ fun FetchingFirstChapterView(storyId: StoryId, chapterId: ChapterId) {
 
         Text(
             text = "(id: ${storyId.id} | Chapter: ${chapterId.id})",
-            style = MaterialTheme.typography.body2,
+            style = M2MaterialTheme.typography.body2,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         )
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        CircularProgressIndicator(
+        M2CircularProgressIndicator(
             modifier = Modifier
                 .width(100.dp)
                 .height(100.dp)
@@ -496,6 +511,30 @@ fun FetchFirstPreview() {
     }
 }
 
+/**
+ * A left-aligned "OR" divider: two [HorizontalDivider]s flanking a small centered label. Used
+ * between the primary "download entire story" action and the expanded specific-chapters card -
+ * it does not appear in the collapsed state (see [ConfirmChapters]).
+ */
+@Composable
+private fun OrDivider(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        HorizontalDivider(modifier = Modifier.weight(1f))
+        Text(
+            text = "OR",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f))
+    }
+}
+
 @Composable
 fun ConfirmChapters(
     storyName: String,
@@ -505,106 +544,201 @@ fun ConfirmChapters(
     driverType: DriverType,
     onUserConfirmation: (ChapterSelection) -> Unit,
     onCancel: () -> Unit = {},
+    // Preview-only hook to render the expanded disclosure state; real callers never pass this.
+    initiallyExpanded: Boolean = false,
 ) {
+    var expanded by remember { mutableStateOf(initiallyExpanded) }
+    var chapterStart by remember { mutableStateOf(initialChapterNumber) }
+    var chapterEnd by remember { mutableStateOf(totalChapters) }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(0.dp, 40.dp, 0.dp, 16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .verticalScroll(rememberScrollState()),
     ) {
-
-        // Story Details
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(text = storyName, style = MaterialTheme.typography.h3)
-
-            Row {
-                Text(text = "By", style = MaterialTheme.typography.subtitle1)
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = authorName,
-                    style = MaterialTheme.typography.subtitle1.copy(fontStyle = FontStyle.Italic)
-                )
-            }
-
-            // TODO Chapter name ?
-            Text(text = if (totalChapters > 1) "$totalChapters chapters" else "One Shot")
-            Text(text = "From: ${driverType.websiteName()}")
-        }
-
-        Spacer(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        )
-
-        // Synchronisation choice
+        // Header: back arrow + story title on a surfaceContainer block. Static (nothing on this
+        // screen scrolls-to-collapse), so a plain Column carries the color/typography rather
+        // than TopAppBar and its scrollBehavior machinery.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .background(MaterialTheme.colorScheme.surfaceContainer),
         ) {
-
-            Surface(elevation = 1.dp) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    contentAlignment = Alignment.Center
+            Row(
+                modifier = Modifier.height(64.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(
+                    onClick = onCancel,
+                    modifier = Modifier.padding(start = 4.dp),
                 ) {
-                    Button(onClick = { onUserConfirmation(ChapterSelection.All) }) {
-                        Text(text = "Synchronise entire story")
-                    }
+                    Icon(
+                        // TODO(redesign-11): swap for Icons.Rounded.ArrowBack once the Material
+                        // Symbols icon set lands (docs/tickets/redesign-11-material-symbols-icons.md)
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = "Back",
+                    )
                 }
             }
 
-            Text("OR", modifier = Modifier.padding(8.dp))
+            Text(
+                text = storyName,
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 16.dp),
+            )
+        }
 
-            Surface(elevation = 1.dp) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp, 8.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "by $authorName",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // This screen is unreachable for one-shot stories (selectChaptersToDownload skips
+            // ConfirmChapters entirely when totalChapters == 1), so the chip is unconditional.
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AssistChip(
+                    onClick = { /* display-only, not interactive */ },
+                    label = { Text("$totalChapters chapters") },
+                    enabled = true,
+                )
+                AssistChip(
+                    onClick = { /* display-only, not interactive */ },
+                    label = { Text(driverType.websiteName()) },
+                    enabled = true,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = { onUserConfirmation(ChapterSelection.All) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Download entire story")
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (!expanded) {
+                // Collapsed: a bare text-button row. No card, no "OR" divider - those only
+                // appear once expanded, below.
+                TextButton(
+                    onClick = { expanded = true },
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
+                    Text(
+                        text = "Choose specific chapters",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        // TODO(redesign-11): swap for Icons.Rounded.ExpandMore once the
+                        // Material Symbols icon set lands
+                        // (docs/tickets/redesign-11-material-symbols-icons.md)
+                        imageVector = Icons.Rounded.KeyboardArrowDown,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            } else {
+                OrDivider()
 
-                    var chapterStart by remember { mutableStateOf(initialChapterNumber) }
-                    var chapterEnd by remember { mutableStateOf(totalChapters) }
-
-                    Button(onClick = {
-                        onUserConfirmation(
-                            if (chapterStart == chapterEnd) {
-                                ChapterSelection.One(chapterStart)
-                            } else {
-                                ChapterSelection.Range(chapterStart, chapterEnd)
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    ),
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Choose specific chapters",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            IconButton(onClick = { expanded = false }) {
+                                Icon(
+                                    // TODO(redesign-11): swap for Icons.Rounded.ExpandLess once
+                                    // the Material Symbols icon set lands
+                                    // (docs/tickets/redesign-11-material-symbols-icons.md)
+                                    imageVector = Icons.Rounded.KeyboardArrowUp,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
                             }
-                        )
-                    }) {
-                        val ch =
-                            if (chapterStart != chapterEnd) "$chapterStart - $chapterEnd" else "$chapterStart"
-                        Text(text = "Synchronise specific chapters ($ch)")
-                    }
+                        }
 
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    // First chapter to download
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text("From", modifier = Modifier.width(64.dp))
-                        Slider(
-                            value = chapterStart.toFloat(),
-                            onValueChange = { chapterStart = it.toInt() },
+                        // One two-thumb slider replaces the old From/To Slider pair. `steps` is
+                        // required, not optional: without it the slider is continuous and
+                        // dragging the two thumbs together - the only way to reach
+                        // ChapterSelection.One below - becomes practically unreachable. `steps`
+                        // counts the values *between* the endpoints, hence totalChapters - 2.
+                        // RangeSlider enforces start <= endInclusive itself, so unlike the old
+                        // "To" Slider there's no need to clamp valueRange against chapterStart.
+                        RangeSlider(
+                            value = chapterStart.toFloat()..chapterEnd.toFloat(),
+                            onValueChange = { range ->
+                                chapterStart = range.start.roundToInt()
+                                chapterEnd = range.endInclusive.roundToInt()
+                            },
                             valueRange = 1f..totalChapters.toFloat(),
+                            steps = (totalChapters - 2).coerceAtLeast(0),
                         )
-                    }
 
-                    // Last chapter to download
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text("To", modifier = Modifier.width(64.dp))
-                        Slider(
-                            value = chapterEnd.toFloat(),
-                            onValueChange = { chapterEnd = it.toInt() },
-                            valueRange = chapterStart.toFloat()..totalChapters.toFloat(),
-                        )
+                        // Track bounds, not the current selection - the selection is reflected
+                        // in the button label below.
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text(
+                                text = "1",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text = "$totalChapters",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        FilledTonalButton(
+                            onClick = {
+                                onUserConfirmation(
+                                    if (chapterStart == chapterEnd) {
+                                        ChapterSelection.One(chapterStart)
+                                    } else {
+                                        ChapterSelection.Range(chapterStart, chapterEnd)
+                                    }
+                                )
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(
+                                text = if (chapterStart == chapterEnd) {
+                                    "Download chapter $chapterStart"
+                                } else {
+                                    // U+2013 en dash, not a hyphen.
+                                    "Download chapters $chapterStart–$chapterEnd"
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -651,6 +785,26 @@ fun ConfirmChaptersDarkPreview() {
     }
 }
 
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    name = "Ask Confirmation (Expanded)",
+)
+@Composable
+fun ConfirmChaptersExpandedPreview() {
+    ReSyncTheme {
+        ConfirmChapters(
+            storyName = "The Story Name",
+            authorName = "The Author Name",
+            initialChapterNumber = 1,
+            totalChapters = 42,
+            driverType = DriverType.ArchiveOfOurOwn,
+            onUserConfirmation = {},
+            initiallyExpanded = true,
+        )
+    }
+}
+
 @Composable
 fun DownloadingRemainingChapters(
     currentlyDownloading: Int,
@@ -668,7 +822,7 @@ fun DownloadingRemainingChapters(
 
         Text(
             text = "Fetching Story",
-            style = MaterialTheme.typography.h6,
+            style = M2MaterialTheme.typography.h6,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -686,14 +840,14 @@ fun DownloadingRemainingChapters(
             // eg. start at 45 and end ta 50, progression is from 90 to 100%.
             // Use the preview tool to understand what bounds we need, then create
             // value classes to enforce 0-indexed or 1-indexed value. Maybe.
-            CircularProgressIndicator(
+            M2CircularProgressIndicator(
                 progress = currentlyDownloading.toFloat() / totalToDownloads,
                 modifier = Modifier
                     .fillMaxSize()
             )
             Text(
                 text = "$currentlyDownloading/${totalToDownloads}\nchapters",
-                style = MaterialTheme.typography.body2,
+                style = M2MaterialTheme.typography.body2,
                 textAlign = TextAlign.Center,
             )
         }
@@ -703,7 +857,7 @@ fun DownloadingRemainingChapters(
 
             Text(
                 text = notice,
-                style = MaterialTheme.typography.body2,
+                style = M2MaterialTheme.typography.body2,
                 textAlign = TextAlign.Center,
             )
         }
@@ -746,12 +900,12 @@ fun DisplayDownloadError(
 
         Text(
             text = "Error while downloading story",
-            style = MaterialTheme.typography.h6,
+            style = M2MaterialTheme.typography.h6,
         )
 
         Text(
             text = "$storyId; $chapterId; DriverType($driverType)",
-            style = MaterialTheme.typography.body2,
+            style = M2MaterialTheme.typography.body2,
             textAlign = TextAlign.Center,
         )
 


### PR DESCRIPTION
## Summary

Rebuilds `ConfirmChapters` (`DownloadScreen.kt`) on M3 per
[docs/tickets/redesign-03-confirm-chapters-screen.md](docs/tickets/redesign-03-confirm-chapters-screen.md):
a `surfaceContainer` header with a back arrow (wired to ticket 04's `onCancel`) and title, a
left-aligned byline + two `AssistChip`s (chapter count / provider), an M3 primary `Button` for
"Download entire story", a disclosure that swaps between a collapsed `TextButton` row and an
expanded `surfaceContainerHighest` `Card` (the "OR" divider only renders in the expanded state,
not hidden/shown), a single `RangeSlider` replacing the two stacked `Slider`s, and a
`FilledTonalButton` secondary action. Copy changed throughout ("Synchronise" → "Download", hyphen
→ en dash), and the dead `"One Shot"` branch is dropped (this screen is unreachable for one-shot
stories — `selectChaptersToDownload` skips it when `totalChapters == 1`).

**Stacked PR** — base is `redesign-02-search-screen` (itself PR #688 against
`redesign-01-scaffold-and-navigation`, PR #687, stacked further on `redesign-04` / `redesign-00`).
None of these are merged yet. Please diff against `redesign-02-search-screen`, not `main`.

## Notable implementation details

- **Icons**: `material-icons-extended` (ticket 11) hasn't landed yet, so `arrow_back` uses
  `Icons.AutoMirrored.Rounded.ArrowBack` (already in the core icon set) and the disclosure
  chevrons use `Icons.Rounded.KeyboardArrowDown`/`KeyboardArrowUp` as stand-ins for
  `expand_more`/`expand_less`, each with a `TODO(redesign-11)` naming the follow-up ticket.
- **Import aliasing**: `FetchingFirstChapterView`, `DownloadingRemainingChapters` and
  `DisplayDownloadError` are untouched (out of scope) but still use M2's
  `MaterialTheme.typography.h6`/`.body2` and the Float-based `CircularProgressIndicator` overload.
  Since `ConfirmChapters` needs `androidx.compose.material3.*` as a wildcard import and both
  packages declare types under the same simple names, those three legacy composables now
  reference the M2 versions via an explicit `as M2MaterialTheme` / `as M2CircularProgressIndicator`
  alias instead of a colliding second wildcard import. No behavior change to those functions.
- **Preview-only `initiallyExpanded` param**: `ConfirmChapters` gained an `initiallyExpanded: Boolean
  = false` parameter so the third preview can render the expanded state; real call sites never pass
  it.

## `RangeSlider` / `ChapterSelection.One` reasoning (unverified on device)

**No Android device or emulator was available in this environment** (`adb`/`emulator` are not on
`PATH`), so the acceptance item asking to drag the thumbs together on-device and log the value
passed to `onUserConfirmation` could not be performed. Reasoning through it instead:

- `RangeSlider(valueRange = 1f..totalChapters.toFloat(), steps = (totalChapters - 2).coerceAtLeast(0))`.
  Compose's `steps` parameter counts allowable values *between* (excluding) the two endpoints of
  `valueRange`. To make every integer chapter 1..totalChapters individually selectable, that's
  `totalChapters` reachable values total, i.e. `totalChapters - 2` values strictly between the
  fixed endpoints — exactly what's passed.
- With `steps = 0` (the value it would silently fall back to without this argument), the slider is
  continuous: Compose's `RangeSlider` implementation enforces a minimum pixel gap between the two
  thumbs when dragging continuously, which makes it very hard to ever get `chapterStart ==
  chapterEnd` — the drag events end up close but the thumbs practically never fully coincide,
  quietly breaking `ChapterSelection.One`.
- With a discrete `steps` grid, both thumbs snap to integer chapter positions on every drag event,
  and Compose's `RangeSlider` allows both thumbs to land on the same step index — dragging the
  "start" thumb up to the "end" thumb's position (or vice versa) reliably produces
  `range.start == range.endInclusive`, and `chapterStart == chapterEnd` is checked directly in
  the secondary button's `onClick` to route to `ChapterSelection.One(chapterStart)`.

This is reasoned, not measured — flagging clearly for human review/verification on a device or
emulator before merge.

## Acceptance criteria

- [x] `ConfirmChapters` uses only `androidx.compose.material3` components (`Button`,
      `FilledTonalButton`, `TextButton`, `Card`, `AssistChip`, `RangeSlider`, `HorizontalDivider`,
      `IconButton`); no `Surface(elevation = …)` remains in it.
- [x] The back arrow invokes a real `onCancel` that returns to Search (wired to ticket 04's
      callback, which cancels the download job, clears the cache, and calls `onDone()`).
- [x] Chapter count and provider render as two `AssistChip`s; `"One Shot"` no longer appears in
      the file.
- [x] Collapsed state shows a `TextButton` with `primary`-colored label and chevron, no card and
      no "OR" divider. Expanding reveals the "OR" divider and the `surfaceContainerHighest` card.
      Both states are covered by previews.
- [x] Exactly one `RangeSlider` and zero `Slider`s appear in `ConfirmChapters`; the `RangeSlider`
      passes a non-null `steps` argument.
- [ ] Dragging the thumbs together and tapping the secondary button produces `ChapterSelection.One`
      — **not verified on a device/emulator** (none available in this environment); see reasoning
      above.
- [x] Button labels read exactly `"Download entire story"`, `"Download chapters X–Y"` (en dash) and
      `"Download chapter X"`; `"Synchronise"` no longer appears anywhere in `DownloadScreen.kt`.
- [x] `ConfirmChaptersLightPreview` / `ConfirmChaptersDarkPreview` render without error, and a
      third preview (`ConfirmChaptersExpandedPreview`) covers the expanded state.

## Test plan

- [x] `./gradlew assembleDebug` — passes
- [x] `./gradlew test` — passes
- [x] `./gradlew lint` — passes
- [ ] Manual verification of `ChapterSelection.One` reachability via `RangeSlider` on a real
      device/emulator (see reasoning above; needs a human or a follow-up run with a device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)