### PR TITLE
Add the Success screen and move sharing behind an explicit button

### DIFF
--- a/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
@@ -8,6 +8,7 @@ import android.webkit.WebView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 // The rest of this file (ConfirmChapters, FetchingFirstChapterView, DownloadingRemainingChapters)
@@ -20,13 +21,16 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme as M2MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,6 +49,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
+import java.io.File
 import java.lang.NumberFormatException
 
 private const val TAG = "DownloadFic"
@@ -90,9 +95,8 @@ fun DownloadScreen(
 
             downloadLogic(context, storyId, chapterId, driverType, driver, setState)
 
-            // Only call onDone if there was no error, otherwise let the user
-            // choose when to close the app.
-            onDone()
+            // Reaching DownloadState.Success is the end of the flow; onDone() is now only
+            // called from the "Done" button on the Success screen (or from onCancel below).
         } catch (e: CancellationException) {
             // Cancellation (see onCancel below) is not an error: don't render the Error
             // screen, and don't call onDone() again - onCancel already does.
@@ -162,6 +166,11 @@ fun DownloadScreen(
                 storyId,
                 chapterId
             )
+            is DownloadState.Success -> DownloadSuccess(
+                summary = state.summary,
+                onShare = { shareEpub(context, state.epubFile, state.fileName) },
+                onDone = onDone,
+            )
         }
     }
 }
@@ -172,7 +181,8 @@ fun DownloadScreen(
     2. if total chapters == 1, skip this step
        Otherwise let user choose what to download
     3. If more than one chapter selected, download remaining chapters
-    4. Build epub and upload to rm cloud
+    4. Build the epub and end on DownloadState.Success; sharing is a separate, explicit user
+       action from there (see shareEpub) rather than something this function does itself.
      */
 suspend fun downloadLogic(
     context: Context,
@@ -205,20 +215,40 @@ suspend fun downloadLogic(
     // refetching already-downloaded chapters.
     clearChapterCache(driver.storyCacheDir(storyId))
 
-    // Direct reMarkable Cloud upload was removed; Share (below) is currently the only
-    // upload path. A future reimplementation of the cloud integration plugs back in here.
-    Log.d(TAG, "Upload via Android Share")
+    // Direct reMarkable Cloud upload was removed; sharing (now behind the "Share to reMarkable"
+    // button on the Success screen, see shareEpub below) is currently the only upload path. A
+    // future reimplementation of the cloud integration plugs back in here.
     // Read how to do so at https://developer.android.com/training/secure-file-sharing
-    // 1. Save the epub on file system
     val epubFile = context.filesDir.resolve("epub/$fileName")
     epubFile.parentFile?.mkdir()
     epubFile.writeBytes(epub)
 
-    // 2. Initiate intent to share epub file
+    val storyName = chaptersInEpub.first().storyName
+    val chapterNums = chaptersInEpub.map { it.num }
+    val summary = when {
+        wholeStory ->
+            "$storyName saved as an EPUB, ready to send to reMarkable."
+        chapterNums.size == 1 ->
+            "$storyName — chapter ${chapterNums.first()} saved as an EPUB, ready to send to reMarkable."
+        else ->
+            "$storyName — chapters ${chapterNums.min()}–${chapterNums.max()} saved as an EPUB, ready to send to reMarkable."
+    }
+
+    setState(DownloadState.Success(epubFile, fileName, storyName, summary))
+}
+
+/**
+ * Fires the Android Share sheet for [file] (an EPUB previously written by [downloadLogic]),
+ * offering it to whatever app the user picks - typically the reMarkable app. Held verbatim from
+ * the code this replaced: the `ClipData`/`EXTRA_STREAM` duplication and the
+ * `FLAG_GRANT_READ_URI_PERMISSION` flag are load-bearing for the reMarkable app, not incidental.
+ */
+private fun shareEpub(context: Context, file: File, fileName: String) {
+    // Read how to do so at https://developer.android.com/training/secure-file-sharing
     val fileUri = FileProvider.getUriForFile(
         context,
         "eu.monniot.resync.fileprovider",
-        epubFile
+        file
     )
 
     val shareIntent: Intent = Intent().apply {
@@ -473,6 +503,13 @@ sealed interface DownloadState {
     ) : DownloadState
 
     data class Error(val throwable: Throwable) : DownloadState
+
+    data class Success(
+        val epubFile: File,
+        val fileName: String,
+        val storyName: String,
+        val summary: String,
+    ) : DownloadState
 }
 
 
@@ -1043,6 +1080,143 @@ fun DisplayDownloadErrorPreview() {
             storyId = StoryId(27855042),
             chapterId = ChapterId(68198782),
             driverType = DriverType.ArchiveOfOurOwn
+        )
+    }
+}
+
+/**
+ * The end of the download flow: a static (no entrance animation - see
+ * docs/tickets/redesign-12-motion-and-animation.md) confirmation that the epub was built, with
+ * sharing as an explicit action rather than an automatic side effect of the download completing.
+ */
+@Composable
+fun DownloadSuccess(
+    summary: String,
+    onShare: () -> Unit,
+    onDone: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(28.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Story ready",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = summary,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = onShare,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Share,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Share to reMarkable")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        TextButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Done")
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    name = "Success (whole story, Light)"
+)
+@Composable
+fun DownloadSuccessWholeStoryPreview() {
+    ReSyncTheme {
+        DownloadSuccess(
+            summary = "The Story Name saved as an EPUB, ready to send to reMarkable.",
+            onShare = {},
+            onDone = {},
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    name = "Success (single chapter, Light)"
+)
+@Composable
+fun DownloadSuccessSingleChapterPreview() {
+    ReSyncTheme {
+        DownloadSuccess(
+            summary = "The Story Name — chapter 3 saved as an EPUB, ready to send to reMarkable.",
+            onShare = {},
+            onDone = {},
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    name = "Success (range, Light)"
+)
+@Composable
+fun DownloadSuccessRangePreview() {
+    ReSyncTheme {
+        DownloadSuccess(
+            summary = "The Story Name — chapters 3–7 saved as an EPUB, ready to send to reMarkable.",
+            onShare = {},
+            onDone = {},
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    name = "Success (range, Dark)"
+)
+@Composable
+fun DownloadSuccessRangeDarkPreview() {
+    ReSyncTheme(darkTheme = true) {
+        DownloadSuccess(
+            summary = "The Story Name — chapters 3–7 saved as an EPUB, ready to send to reMarkable.",
+            onShare = {},
+            onDone = {},
         )
     }
 }


### PR DESCRIPTION
## Summary

Implements [docs/tickets/redesign-06-success-screen.md](docs/tickets/redesign-06-success-screen.md).

This is a real **behavior change**: today `downloadLogic` fires the Android share sheet itself the instant the epub is built, and `DownloadScreen`'s `LaunchedEffect` immediately calls `onDone()`, bouncing straight back to Search without the user ever seeing a confirmation. After this PR:

- `DownloadState` gains a `Success(epubFile, fileName, storyName, summary)` case. `downloadLogic` builds the epub, writes it to disk, computes the `summary` line (whole story / single chapter / range wording, em dash after the title, en dash in ranges), and ends with `setState(DownloadState.Success(...))` — it no longer references `Intent.ACTION_SEND`, `FileProvider`, or `startActivity` at all.
- The deleted share-intent code moved **verbatim** into a new private `shareEpub(context, file, fileName)` function — same `ClipData`/`EXTRA_STREAM` duplication and `FLAG_GRANT_READ_URI_PERMISSION` flag, untouched, since the ticket calls those load-bearing for the reMarkable app.
- `DownloadScreen`'s `LaunchedEffect` no longer calls `onDone()` on a successful download. Reaching `Success` is now the end of the flow; the only way out is the new `DownloadSuccess` composable's "Done" button (or cancel, unaffected).
- New `DownloadSuccess(summary, onShare, onDone)` composable: 56dp `primaryContainer` circle with a centered 28dp check icon, "Story ready" headline, summary body text, full-width "Share to reMarkable" button (with leading share icon — available, see below), and a "Done" text button. Static, no entrance animation (ticket 12's job). Material3-only components.

## Acceptance criteria

- [x] `DownloadState` has a `Success` case, and `DownloadScreen`'s `when (state)` handles it (compiler-enforced exhaustiveness).
- [x] `Intent.ACTION_SEND`, `FileProvider` and `startActivity` appear in exactly one place in `DownloadScreen.kt` — inside `shareEpub` — and `downloadLogic` no longer references any of them.
- [x] `downloadLogic` ends by calling `setState(DownloadState.Success(...))`.
- [x] `DownloadScreen`'s `LaunchedEffect` no longer calls `onDone()`; the only `onDone()` call reachable from a successful download is the "Done" `TextButton`.
- [x] The summary line renders all three cases correctly. Verified with three previews (`DownloadSuccessWholeStoryPreview`, `DownloadSuccessSingleChapterPreview`, `DownloadSuccessRangePreview`, plus a dark-theme range preview) rather than on-device.
- [ ] Manual verification on a device or emulator — **not performed, no device/emulator available in this environment**. See reasoning below.
- [x] (reasoned, not device-verified) The same flow through `DeepLinkActivity` ends with "Done" calling `finish()`.
- [x] `DownloadSuccess` uses only `androidx.compose.material3` components.
- [x] `./gradlew assembleDebug` and `./gradlew test` pass.

## Device verification — reasoning (unverified on device)

No device/emulator was available in this environment, so the on-device item is traced through code instead of run:

- **Share sheet doesn't auto-open**: `downloadLogic` no longer contains any `Intent`/`FileProvider`/`startActivity` code — it only calls `setState(DownloadState.Success(...))`. The only caller of `shareEpub` is the `onShare` lambda wired to the "Share to reMarkable" `Button`'s `onClick` in `DownloadScreen`'s `when (state)` branch, so it cannot fire without a tap.
- **"Share to reMarkable" opens the share sheet with the epub**: `shareEpub` is the deleted block moved verbatim (same `FileProvider` authority `eu.monniot.resync.fileprovider`, same `ClipData`/`EXTRA_STREAM` duplication, same `FLAG_GRANT_READ_URI_PERMISSION`), so its runtime behavior is unchanged from what previously worked automatically.
- **"Done" returns to Search**: `SearchStoryScreen.kt:54` passes `onDone = { storySelected.value = false }` into `DownloadScreen`. Flipping `storySelected` back to `false` makes `SearchStoryScreen` render `StorySelectionView` again (the `if (storySelected.value) DownloadScreen(...) else StorySelectionView(...)` branch at lines 45-60), i.e. Search.
- **Via `DeepLinkActivity`, "Done" calls `finish()`**: `DeepLinkActivity.kt:32` passes `onDone = { finish() }` directly into `DownloadScreen`, unchanged by this PR — tapping "Done" now is the only path that reaches this `onDone`, and it closes the activity as before.

## Other notes

- The share icon (`Icons.Rounded.Share`) **is** available in `material-icons-core` (confirmed by inspecting the dependency jar), same as `Icons.Rounded.Check`, so the button ships with the leading share icon per the design — no `TODO`/text-only fallback was needed.
- Comment cleanup: updated the flow comment above `downloadLogic` (step 4) and the "Direct reMarkable Cloud upload was removed" comment to reflect that sharing is now behind `shareEpub`, called from the Success screen rather than something `downloadLogic` does itself.

## Stacking

This PR is stacked: base branch is `redesign-05-downloading-screen` (PR #690), itself stacked on redesign-03 (#689) → redesign-02 (#688) → redesign-01 (#687) → redesign-04 (#686) → redesign-00 (#685). **None of these are merged yet** — please diff against `redesign-05-downloading-screen`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)