### PR TITLE
Rebuild the Settings screen on M3 components

### DIFF
--- a/app/src/main/java/eu/monniot/resync/ui/launcher/SettingsScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/launcher/SettingsScreen.kt
@@ -2,13 +2,17 @@ package eu.monniot.resync.ui.launcher
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import eu.monniot.resync.ui.ReSyncTheme
 
 // Direct reMarkable Cloud pairing/account management was removed; downloaded stories
 // currently go out through the Android Share sheet only. This screen is the anchor point
@@ -21,16 +25,79 @@ fun SettingsScreen() {
 @Composable
 fun SettingsView() {
     Column(Modifier.padding(top = 8.dp)) {
+        SettingsGroup(title = "Account") {
+            SettingsMenuLine(
+                title = { SettingsTileTitle { Text("Sign in to reMarkable Cloud") } },
+                subtitle = { SettingsTileSubtitle { Text("Not signed in") } },
+                action = {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                // Placeholder — no backing functionality yet. See
+                // docs/tickets/redesign-10-settings-screen.md; wire up when the cloud
+                // integration lands (CLAUDE.md § reMarkable Cloud).
+                onClick = {},
+            )
+        }
+
+        SettingsGroup(title = "Sync") {
+            SettingsMenuLine(
+                title = { SettingsTileTitle { Text("Sync frequency") } },
+                subtitle = { SettingsTileSubtitle { Text("Manual") } },
+                action = {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                // Placeholder — no backing functionality yet. See
+                // docs/tickets/redesign-10-settings-screen.md; wire up when the cloud
+                // integration lands (CLAUDE.md § reMarkable Cloud).
+                onClick = {},
+            )
+        }
+
+        SettingsGroup(title = "Storage") {
+            SettingsMenuLine(
+                title = { SettingsTileTitle { Text("Local storage") } },
+                subtitle = { SettingsTileSubtitle { Text("128 MB used") } },
+                action = {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                // Placeholder — no backing functionality yet. See
+                // docs/tickets/redesign-10-settings-screen.md; wire up when the cloud
+                // integration lands (CLAUDE.md § reMarkable Cloud).
+                onClick = {},
+            )
+        }
+
         SettingsGroup(title = "reMarkable Cloud") {
-            Box(
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                ),
+                shape = RoundedCornerShape(12.dp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
             ) {
-                Text(
-                    "Direct reMarkable Cloud integration is being rebuilt. For now, use the " +
-                            "Share sheet after downloading a story to send it to the reMarkable app."
-                )
+                Column(Modifier.padding(16.dp)) {
+                    Text("Direct integration is being rebuilt", style = MaterialTheme.typography.bodyLarge)
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "Use the Share sheet after downloading a story to send it to reMarkable for now.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }
@@ -45,19 +112,14 @@ fun SettingsGroup(
     ) {
         // Group title
 
-        Divider(Modifier.padding(top=8.dp))
-
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(32.dp)
-                .padding(start = (16 + 40 + 8).dp, 8.dp, 16.dp, 8.dp),
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 8.dp),
             contentAlignment = Alignment.CenterStart
         ) {
-
-
-            val primary = MaterialTheme.colors.primary
-            val titleStyle = MaterialTheme.typography.subtitle2.copy(color = primary)
+            val primary = MaterialTheme.colorScheme.primary
+            val titleStyle = MaterialTheme.typography.labelLarge.copy(color = primary)
             Text(style = titleStyle, text = title)
         }
 
@@ -77,7 +139,7 @@ fun SettingsMenuLine(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .heightIn(min = 72.dp)
     ) {
         Row(
             modifier = Modifier
@@ -89,7 +151,7 @@ fun SettingsMenuLine(
                 title = title,
                 subtitle = subtitle,
                 modifier = Modifier
-                    .padding(start = (16 + 40 + 8).dp)
+                    .padding(start = 16.dp)
                     .fillMaxHeight()
             )
         }
@@ -104,17 +166,19 @@ fun SettingsMenuLine(
 
 @Composable
 internal fun SettingsTileTitle(title: @Composable () -> Unit) {
-    ProvideTextStyle(value = MaterialTheme.typography.subtitle1) {
+    ProvideTextStyle(value = MaterialTheme.typography.bodyLarge) {
         title()
     }
 }
 
 @Composable
 internal fun SettingsTileSubtitle(subtitle: @Composable () -> Unit) {
-    ProvideTextStyle(value = MaterialTheme.typography.caption) {
-        CompositionLocalProvider(
-            LocalContentAlpha provides ContentAlpha.medium, content = subtitle
+    ProvideTextStyle(
+        value = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    ) {
+        subtitle()
     }
 }
 
@@ -139,7 +203,7 @@ internal fun RowScope.SettingsTileTexts(
 @Composable
 internal fun SettingsTileAction(content: @Composable () -> Unit) {
     Box(
-        modifier = Modifier.size(64.dp),
+        modifier = Modifier.size(48.dp),
         contentAlignment = Alignment.Center,
     ) {
         content()
@@ -150,10 +214,24 @@ internal fun SettingsTileAction(content: @Composable () -> Unit) {
     showBackground = true,
     device = Devices.PIXEL_3,
     showSystemUi = true,
+    name = "Settings (Light)",
 )
 @Composable
 internal fun SettingsScreenPreview() {
-    MaterialTheme {
+    ReSyncTheme {
+        SettingsView()
+    }
+}
+
+@Preview(
+    showBackground = true,
+    device = Devices.PIXEL_3,
+    showSystemUi = true,
+    name = "Settings (Dark)",
+)
+@Composable
+internal fun SettingsScreenDarkPreview() {
+    ReSyncTheme(darkTheme = true) {
         SettingsView()
     }
 }


### PR DESCRIPTION
## Summary

Rebuilds `SettingsScreen.kt` on Material 3 per `docs/tickets/redesign-10-settings-screen.md`:

- Token swaps: `colors.primary`/`typography.subtitle2` → `colorScheme.primary`/`typography.labelLarge`; `typography.subtitle1` → `bodyLarge`; `typography.caption` + `LocalContentAlpha`/`ContentAlpha.medium` → `bodyMedium` + explicit `onSurfaceVariant` (the `CompositionLocalProvider` wrapper is gone, M3 has no equivalent).
- Structural fixes: removed the leftover `(16 + 40 + 8).dp` leading-icon inset from `SettingsGroup`'s header and `SettingsMenuLine`'s texts; `SettingsMenuLine` now `heightIn(min = 72.dp)` instead of a fixed `height(48.dp)`; deleted `SettingsGroup`'s `Divider` entirely (no port to `HorizontalDivider` — the design has none).
- Wired the previously-unused `action` slot with `Icons.AutoMirrored.Rounded.KeyboardArrowRight` tinted `onSurfaceVariant`; narrowed `SettingsTileAction`'s box from 64dp to `size(48.dp)`.
- Added three inert placeholder `SettingsGroup`s (Account/Sync/Storage) above the reMarkable Cloud group, each `onClick = {}` with a comment pointing at the ticket and `CLAUDE.md` § reMarkable Cloud.
- Replaced the reMarkable Cloud `Box`+`Text` with a `surfaceContainerHighest` 12dp `Card` (title + body lines); the body sentence is byte-identical to `ConsolidateScreen.kt`'s no-account subtitle from ticket 08 (verified below).
- `SettingsScreenPreview` now uses `ReSyncTheme`, plus a new dark variant.

Stacked on `redesign-09-consolidate-refresh-and-sheet` (PR #694), itself stacked on the full chain back through redesign-00 (#685) — none of it merged yet. **Diff against `redesign-09-consolidate-refresh-and-sheet`, not `main`.**

## Acceptance criteria

- [x] `SettingsScreen.kt` imports `androidx.compose.material3.*` and contains no `androidx.compose.material.*` import.
- [x] `LocalContentAlpha`, `ContentAlpha` and `Divider` no longer appear in the file.
- [x] `(16 + 40 + 8).dp` no longer appears in the file; headers and row text start at 16dp.
- [x] `SettingsMenuLine` uses `heightIn(min = 72.dp)`, not a fixed 48dp.
- [x] Account, Sync and Storage sections render with the exact copy in the table, each with a trailing chevron and an `onClick = {}` carrying the placeholder comment.
- [x] The reMarkable Cloud card is a `surfaceContainerHighest` 12dp card with a `bodyLarge` title line and a `bodyMedium`/`onSurfaceVariant` body line.
- [x] The card's body sentence is byte-identical to the no-account subtitle in redesign-08 (grepped, two hits).
- [x] `SettingsScreenPreview` uses `ReSyncTheme`, and a dark variant exists; both render without error and show all four sections.
- [x] `./gradlew assembleDebug` and `./gradlew lint` pass.

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew lint` — BUILD SUCCESSFUL
- [x] Grepped both `SettingsScreen.kt` and `ConsolidateScreen.kt` to confirm the reMarkable Cloud card body sentence is byte-identical to the Consolidate no-account subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)