### PR TITLE
Apply the M3 motion spec

### DIFF
--- a/app/src/main/java/eu/monniot/resync/ui/Motion.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/Motion.kt
@@ -1,0 +1,12 @@
+package eu.monniot.resync.ui
+
+import androidx.compose.animation.core.CubicBezierEasing
+
+/**
+ * The design's "emphasized decelerate" easing curve (see
+ * docs/tickets/redesign-12-motion-and-animation.md). The M3 library's own
+ * `androidx.compose.material3.tokens.MotionTokens.EmphasizedDecelerateCubicBezier` isn't usable -
+ * that package is internal - so this is a hand-transcribed equivalent, declared once here and
+ * reused by every screen-level transition instead of each screen rolling its own.
+ */
+val EmphasizedEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)

--- a/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/downloader/DownloadScreen.kt
@@ -7,6 +7,19 @@ import android.os.Build
 import android.util.Log
 import android.webkit.WebView
 import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -18,7 +31,6 @@ import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Error
-import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material3.*
@@ -26,12 +38,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -41,6 +55,7 @@ import eu.monniot.resync.BuildConfig
 import eu.monniot.resync.FileName
 import eu.monniot.resync.downloader.*
 import eu.monniot.resync.makeEpub
+import eu.monniot.resync.ui.EmphasizedEasing
 import eu.monniot.resync.ui.KeepScreenOn
 import eu.monniot.resync.ui.ReSyncTheme
 import kotlinx.coroutines.CancellationException
@@ -150,41 +165,60 @@ fun DownloadScreen(
             driver.installGrabber(webView)
         }
 
-        when (state) {
-            is DownloadState.FetchingFirstChapter -> FetchingFirstChapterView(
-                storyId = state.storyId,
-                chapterId = state.chapterId,
-                onCancel = onCancel,
-            )
-            is DownloadState.ConfirmChapters -> ConfirmChapters(
-                state.storyName,
-                state.authorName,
-                state.initialChapterNumber,
-                state.totalChapters,
-                state.driverType,
-                state.onUserConfirmation,
-                onCancel = onCancel,
-            )
-            is DownloadState.DownloadingRemainingChapters -> DownloadingRemainingChapters(
-                storyName = state.storyName,
-                currentlyDownloading = state.currentlyDownloading,
-                totalToDownloads = state.totalToDownloads,
-                notice = state.notice,
-                onCancel = onCancel,
-            )
-            is DownloadState.Error -> DisplayDownloadError(
-                error = state.throwable,
-                driverType = driverType,
-                storyId = storyId,
-                chapterId = chapterId,
-                onRetry = onRetry,
-                onDone = onCancel,
-            )
-            is DownloadState.Success -> DownloadSuccess(
-                summary = state.summary,
-                onShare = { shareEpub(context, state.epubFile, state.fileName) },
-                onDone = onDone,
-            )
+        // Shared-axis-X screen transition between DownloadState states. contentKey = { it::class }
+        // is load-bearing: DownloadingRemainingChapters emits a new instance per chapter, and
+        // without keying on the class alone every chapter update would re-trigger the full
+        // screen transition instead of just updating in place (see
+        // docs/tickets/redesign-12-motion-and-animation.md item 3). The `s` lambda parameter is
+        // used below, not `state` directly, for the same reason as the Search<->Download
+        // transition.
+        AnimatedContent(
+            targetState = state,
+            contentKey = { it::class },
+            transitionSpec = {
+                val offsetSpec = tween<IntOffset>(300, easing = EmphasizedEasing)
+                val fadeSpec = tween<Float>(300, easing = EmphasizedEasing)
+                (slideInHorizontally(offsetSpec) { it / 4 } + fadeIn(fadeSpec)) togetherWith
+                        (slideOutHorizontally(offsetSpec) { -it / 4 } + fadeOut(fadeSpec))
+            },
+            label = "downloadState",
+        ) { s ->
+            when (s) {
+                is DownloadState.FetchingFirstChapter -> FetchingFirstChapterView(
+                    storyId = s.storyId,
+                    chapterId = s.chapterId,
+                    onCancel = onCancel,
+                )
+                is DownloadState.ConfirmChapters -> ConfirmChapters(
+                    s.storyName,
+                    s.authorName,
+                    s.initialChapterNumber,
+                    s.totalChapters,
+                    s.driverType,
+                    s.onUserConfirmation,
+                    onCancel = onCancel,
+                )
+                is DownloadState.DownloadingRemainingChapters -> DownloadingRemainingChapters(
+                    storyName = s.storyName,
+                    currentlyDownloading = s.currentlyDownloading,
+                    totalToDownloads = s.totalToDownloads,
+                    notice = s.notice,
+                    onCancel = onCancel,
+                )
+                is DownloadState.Error -> DisplayDownloadError(
+                    error = s.throwable,
+                    driverType = driverType,
+                    storyId = storyId,
+                    chapterId = chapterId,
+                    onRetry = onRetry,
+                    onDone = onCancel,
+                )
+                is DownloadState.Success -> DownloadSuccess(
+                    summary = s.summary,
+                    onShare = { shareEpub(context, s.epubFile, s.fileName) },
+                    onDone = onDone,
+                )
+            }
         }
     }
 }
@@ -657,6 +691,14 @@ fun ConfirmChapters(
     var chapterStart by remember { mutableStateOf(initialChapterNumber) }
     var chapterEnd by remember { mutableStateOf(totalChapters) }
 
+    // One chevron vector, rotated 180 degrees when expanded, shared by the collapsed
+    // TextButton's trailing icon and the expanded Card's collapse IconButton below - rather than
+    // swapping between ExpandMore/ExpandLess assets.
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "chooseChaptersChevron",
+    )
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -730,9 +772,11 @@ fun ConfirmChapters(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            if (!expanded) {
-                // Collapsed: a bare text-button row. No card, no "OR" divider - those only
-                // appear once expanded, below.
+            // Collapsed: a bare text-button row. No card, no "OR" divider - those only appear
+            // once expanded, below. The collapsed state is a TextButton and the expanded state
+            // is a Card - not one container that grows - so each gets its own AnimatedVisibility
+            // rather than a single container animating open.
+            AnimatedVisibility(visible = !expanded) {
                 TextButton(
                     onClick = { expanded = true },
                     modifier = Modifier.fillMaxWidth(),
@@ -747,95 +791,106 @@ fun ConfirmChapters(
                         imageVector = Icons.Rounded.ExpandMore,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.rotate(chevronRotation),
                     )
                 }
-            } else {
-                OrDivider()
+            }
 
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                    ),
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = "Choose specific chapters",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically(tween(300, easing = EmphasizedEasing)) + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                Column {
+                    OrDivider()
+
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        ),
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "Choose specific chapters",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                IconButton(onClick = { expanded = false }) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.ExpandMore,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.rotate(chevronRotation),
+                                    )
+                                }
+                            }
+
+                            // One two-thumb slider replaces the old From/To Slider pair. `steps`
+                            // is required, not optional: without it the slider is continuous and
+                            // dragging the two thumbs together - the only way to reach
+                            // ChapterSelection.One below - becomes practically unreachable.
+                            // `steps` counts the values *between* the endpoints, hence
+                            // totalChapters - 2. RangeSlider enforces start <= endInclusive
+                            // itself, so unlike the old "To" Slider there's no need to clamp
+                            // valueRange against chapterStart.
+                            RangeSlider(
+                                value = chapterStart.toFloat()..chapterEnd.toFloat(),
+                                onValueChange = { range ->
+                                    chapterStart = range.start.roundToInt()
+                                    chapterEnd = range.endInclusive.roundToInt()
+                                },
+                                valueRange = 1f..totalChapters.toFloat(),
+                                steps = (totalChapters - 2).coerceAtLeast(0),
                             )
-                            IconButton(onClick = { expanded = false }) {
-                                Icon(
-                                    imageVector = Icons.Rounded.ExpandLess,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
+
+                            // Track bounds, not the current selection - the selection is
+                            // reflected in the button label below.
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Text(
+                                    text = "1",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    text = "$totalChapters",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
-                        }
 
-                        // One two-thumb slider replaces the old From/To Slider pair. `steps` is
-                        // required, not optional: without it the slider is continuous and
-                        // dragging the two thumbs together - the only way to reach
-                        // ChapterSelection.One below - becomes practically unreachable. `steps`
-                        // counts the values *between* the endpoints, hence totalChapters - 2.
-                        // RangeSlider enforces start <= endInclusive itself, so unlike the old
-                        // "To" Slider there's no need to clamp valueRange against chapterStart.
-                        RangeSlider(
-                            value = chapterStart.toFloat()..chapterEnd.toFloat(),
-                            onValueChange = { range ->
-                                chapterStart = range.start.roundToInt()
-                                chapterEnd = range.endInclusive.roundToInt()
-                            },
-                            valueRange = 1f..totalChapters.toFloat(),
-                            steps = (totalChapters - 2).coerceAtLeast(0),
-                        )
+                            Spacer(modifier = Modifier.height(12.dp))
 
-                        // Track bounds, not the current selection - the selection is reflected
-                        // in the button label below.
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text(
-                                text = "1",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = "$totalChapters",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.height(12.dp))
-
-                        FilledTonalButton(
-                            onClick = {
-                                onUserConfirmation(
-                                    if (chapterStart == chapterEnd) {
-                                        ChapterSelection.One(chapterStart)
+                            FilledTonalButton(
+                                onClick = {
+                                    onUserConfirmation(
+                                        if (chapterStart == chapterEnd) {
+                                            ChapterSelection.One(chapterStart)
+                                        } else {
+                                            ChapterSelection.Range(chapterStart, chapterEnd)
+                                        }
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text(
+                                    text = if (chapterStart == chapterEnd) {
+                                        "Download chapter $chapterStart"
                                     } else {
-                                        ChapterSelection.Range(chapterStart, chapterEnd)
+                                        // U+2013 en dash, not a hyphen.
+                                        "Download chapters $chapterStart–$chapterEnd"
                                     }
                                 )
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(
-                                text = if (chapterStart == chapterEnd) {
-                                    "Download chapter $chapterStart"
-                                } else {
-                                    // U+2013 en dash, not a hyphen.
-                                    "Download chapters $chapterStart–$chapterEnd"
-                                }
-                            )
+                            }
                         }
                     }
                 }
@@ -929,8 +984,16 @@ fun DownloadingRemainingChapters(
             // eg. start at 45 and end ta 50, progression is from 90 to 100%.
             // Use the preview tool to understand what bounds we need, then create
             // value classes to enforce 0-indexed or 1-indexed value. Maybe.
+            //
+            // The raw ratio is backed by animateFloatAsState so the arc sweeps between chapters
+            // instead of jumping a whole chapter's worth of progress at once.
+            val animatedProgress by animateFloatAsState(
+                targetValue = currentlyDownloading.toFloat() / totalToDownloads,
+                animationSpec = tween(400),
+                label = "downloadProgress",
+            )
             CircularProgressIndicator(
-                progress = { currentlyDownloading.toFloat() / totalToDownloads },
+                progress = { animatedProgress },
                 modifier = Modifier.size(64.dp),
             )
 
@@ -1043,6 +1106,17 @@ fun DisplayDownloadError(
 
     var expanded by remember { mutableStateOf(initiallyExpanded) }
 
+    // One chevron vector, rotated 180 degrees when expanded, rather than swapping between
+    // ExpandMore/ExpandLess assets.
+    val detailsChevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "technicalDetailsChevron",
+    )
+
+    // Plays once on first composition of this screen, landing just after the ~300ms
+    // Search<->Download / DownloadState screen transition settles rather than during it.
+    val circleVisibleState = remember { MutableTransitionState(false).apply { targetState = true } }
+
     Column(
         verticalArrangement = if (expanded) Arrangement.Top else Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -1053,19 +1127,27 @@ fun DisplayDownloadError(
             .padding(horizontal = 24.dp)
             .then(if (expanded) Modifier.padding(top = 32.dp) else Modifier),
     ) {
-        Box(
-            modifier = Modifier
-                .size(56.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.errorContainer),
-            contentAlignment = Alignment.Center,
+        AnimatedVisibility(
+            visibleState = circleVisibleState,
+            enter = scaleIn(
+                initialScale = 0.6f,
+                animationSpec = tween(200, delayMillis = 150),
+            ) + fadeIn(animationSpec = tween(200, delayMillis = 150)),
         ) {
-            Icon(
-                imageVector = Icons.Rounded.Error,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onErrorContainer,
-                modifier = Modifier.size(28.dp),
-            )
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.errorContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Error,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.size(28.dp),
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -1128,37 +1210,40 @@ fun DisplayDownloadError(
             Text("Technical details")
             Spacer(modifier = Modifier.width(4.dp))
             Icon(
-                imageVector = if (expanded) {
-                    Icons.Rounded.ExpandLess
-                } else {
-                    Icons.Rounded.ExpandMore
-                },
+                imageVector = Icons.Rounded.ExpandMore,
                 contentDescription = null,
+                modifier = Modifier.rotate(detailsChevronRotation),
             )
         }
 
-        if (expanded) {
-            Spacer(modifier = Modifier.height(8.dp))
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically(tween(300, easing = EmphasizedEasing)) + fadeIn(),
+            exit = shrinkVertically() + fadeOut(),
+        ) {
+            Column {
+                Spacer(modifier = Modifier.height(8.dp))
 
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                ),
-                shape = RoundedCornerShape(12.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(
-                    text = errorDetailsText(error, driverType, storyId, chapterId),
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        fontFamily = FontFamily.Monospace,
-                        lineHeight = 20.sp,
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                     ),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Start,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                )
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = errorDetailsText(error, driverType, storyId, chapterId),
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            lineHeight = 20.sp,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Start,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    )
+                }
             }
         }
     }
@@ -1274,6 +1359,8 @@ fun DisplayDownloadErrorExpandedDarkPreview() {
  * The end of the download flow: a static (no entrance animation - see
  * docs/tickets/redesign-12-motion-and-animation.md) confirmation that the epub was built, with
  * sharing as an explicit action rather than an automatic side effect of the download completing.
+ * The tonal circle scales/fades in on first composition (see [DownloadSuccess]'s
+ * `circleVisibleState`), landing just after the screen transition into this state settles.
  */
 @Composable
 fun DownloadSuccess(
@@ -1281,6 +1368,10 @@ fun DownloadSuccess(
     onShare: () -> Unit,
     onDone: () -> Unit,
 ) {
+    // Plays once on first composition of this screen, landing just after the ~300ms
+    // Search<->Download / DownloadState screen transition settles rather than during it.
+    val circleVisibleState = remember { MutableTransitionState(false).apply { targetState = true } }
+
     Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -1288,19 +1379,27 @@ fun DownloadSuccess(
             .fillMaxSize()
             .padding(horizontal = 24.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .size(56.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primaryContainer),
-            contentAlignment = Alignment.Center,
+        AnimatedVisibility(
+            visibleState = circleVisibleState,
+            enter = scaleIn(
+                initialScale = 0.6f,
+                animationSpec = tween(200, delayMillis = 150),
+            ) + fadeIn(animationSpec = tween(200, delayMillis = 150)),
         ) {
-            Icon(
-                imageVector = Icons.Rounded.Check,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.size(28.dp),
-            )
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(28.dp),
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/eu/monniot/resync/ui/launcher/LauncherScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/launcher/LauncherScreen.kt
@@ -1,5 +1,10 @@
 package eu.monniot.resync.ui.launcher
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
@@ -68,10 +73,22 @@ fun LauncherScreen(
                         selected = itemSelected,
                         onClick = { selectedItem = item },
                         icon = {
-                            Icon(
-                                if (itemSelected) item.iconFilled else item.iconOutline,
-                                contentDescription = null,
-                            )
+                            // The pill indicator behind this icon animates for free via
+                            // NavigationBarItem (no colors = override suppressing it, per
+                            // redesign-01). This AnimatedContent only handles the outline<->filled
+                            // icon crossfade on top of it.
+                            AnimatedContent(
+                                targetState = itemSelected,
+                                transitionSpec = {
+                                    fadeIn(tween(150)) togetherWith fadeOut(tween(150))
+                                },
+                                label = "navIcon",
+                            ) { selected ->
+                                Icon(
+                                    if (selected) item.iconFilled else item.iconOutline,
+                                    contentDescription = null,
+                                )
+                            }
                         },
                         label = { Text(item.sectionName) },
                     )

--- a/app/src/main/java/eu/monniot/resync/ui/launcher/SearchStoryScreen.kt
+++ b/app/src/main/java/eu/monniot/resync/ui/launcher/SearchStoryScreen.kt
@@ -1,5 +1,12 @@
 package eu.monniot.resync.ui.launcher
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,10 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import eu.monniot.resync.downloader.ChapterId
 import eu.monniot.resync.downloader.DriverType
 import eu.monniot.resync.downloader.StoryId
+import eu.monniot.resync.ui.EmphasizedEasing
 import eu.monniot.resync.ui.ReSyncTheme
 import eu.monniot.resync.ui.downloader.DownloadScreen
 
@@ -47,20 +56,36 @@ fun SearchStoryScreen() {
     val driverType = remember { mutableStateOf(DriverType.ArchiveOfOurOwn) }
     val storySelected = remember { mutableStateOf(false) }
 
-    if (storySelected.value) {
-        // Safe: the Sync button in StorySelectionView is only enabled when
-        // canSyncStory(storyId, chapterId) holds, which guarantees both fields parse as Int.
-        val sid = StoryId(storyId.value.text.toInt())
-        val cid = ChapterId(chapterId.value.text.ifBlank { null }?.toInt())
-        DownloadScreen(
-            driverType = driverType.value,
-            storyId = sid,
-            chapterId = cid,
-            onDone = { storySelected.value = false }
-        )
-    } else {
-        StorySelectionView(storyId, chapterId, driverType) {
-            storySelected.value = true
+    // Shared-axis-X screen transition between the search form and the download flow. The
+    // AnimatedContent's `selected` lambda parameter is used to pick the branch below - not
+    // storySelected.value directly - otherwise both the outgoing and incoming frames would
+    // render the new screen and the transition would look broken (see
+    // docs/tickets/redesign-12-motion-and-animation.md item 2).
+    AnimatedContent(
+        targetState = storySelected.value,
+        transitionSpec = {
+            val offsetSpec = tween<IntOffset>(300, easing = EmphasizedEasing)
+            val fadeSpec = tween<Float>(300, easing = EmphasizedEasing)
+            (slideInHorizontally(offsetSpec) { it / 4 } + fadeIn(fadeSpec)) togetherWith
+                    (slideOutHorizontally(offsetSpec) { -it / 4 } + fadeOut(fadeSpec))
+        },
+        label = "searchDownload",
+    ) { selected ->
+        if (selected) {
+            // Safe: the Sync button in StorySelectionView is only enabled when
+            // canSyncStory(storyId, chapterId) holds, which guarantees both fields parse as Int.
+            val sid = StoryId(storyId.value.text.toInt())
+            val cid = ChapterId(chapterId.value.text.ifBlank { null }?.toInt())
+            DownloadScreen(
+                driverType = driverType.value,
+                storyId = sid,
+                chapterId = cid,
+                onDone = { storySelected.value = false }
+            )
+        } else {
+            StorySelectionView(storyId, chapterId, driverType) {
+                storySelected.value = true
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements `docs/tickets/redesign-12-motion-and-animation.md` — the polish pass that animates components every prior ticket built statically:

- **Nav bar** (`LauncherScreen.kt`): outline↔filled icon crossfade via `AnimatedContent` (150ms fade). The pill indicator was already animating for free.
- **Search↔Download** and **`DownloadState`** transitions (`SearchStoryScreen.kt`, `DownloadScreen.kt`): shared-axis-X `AnimatedContent`, 300ms, using a single `EmphasizedEasing` constant. Both read content from the lambda parameter, not the outer state. The `DownloadState` one passes `contentKey = { it::class }` so per-chapter state updates don't retrigger the screen transition.
- **Chapter-picker disclosure** and **error "Technical details" disclosure**: `AnimatedVisibility` open/close, with a single rotating chevron (`Modifier.rotate` + `animateFloatAsState`) replacing the swapped `ExpandMore`/`ExpandLess` vectors — `ExpandLess` is no longer imported.
- **Downloading progress ring**: wrapped in `animateFloatAsState(tween(400))` so it sweeps between chapters instead of jumping.
- **Success/Error circle entrance**: `AnimatedVisibility` (`MutableTransitionState`) with `scaleIn(initialScale = 0.6f) + fadeIn()`, `tween(200, delayMillis = 150)`.
- New `ui/Motion.kt` declares `val EmphasizedEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)` — the two corrections from the ticket (no NavHost in this app, `MotionTokens` is internal) are applied throughout; no file imports `androidx.compose.material3.tokens`.

Search fields, `RangeSlider`, and Consolidate list rows needed no code changes — verified below.

This PR is **stacked**: base is `redesign-11-material-symbols-icons` (PR #696), itself stacked further back through redesign-00, none of which are merged yet. Please diff against that branch, not `main`.

## Acceptance criteria

- [x] A single `EmphasizedEasing` constant exists and is used by every screen-level transition in this ticket; no file imports `androidx.compose.material3.tokens`.
- [x] Nav bar: the active pill animates, and the icon crossfades between outline and filled.
- [x] Search↔Download and `DownloadState` transitions are shared-axis-X, ~300ms, `EmphasizedEasing`.
- [x] The `DownloadState` `AnimatedContent` passes `contentKey = { it::class }` — advancing from chapter 3 to chapter 4 does not re-trigger the screen transition. **Not verified on a device/emulator** (none available in this environment) — reasoned through instead, see below.
- [x] Both `AnimatedContent` blocks read their content from the lambda parameter, not from the state they're keyed on.
- [x] The chapter-picker and "Technical details" disclosures animate open and closed, and each uses one rotating chevron rather than two swapped vectors.
- [x] The progress ring sweeps between chapters instead of jumping. **Not verified on a device/emulator** — reasoned through instead, see below.
- [x] The Success and Error circles scale in after the screen transition settles, not during it.
- [x] `./gradlew assembleDebug` and `./gradlew test` pass.

## Device-verification reasoning (no device/emulator available)

**`contentKey` preventing per-chapter re-transitions**: `AnimatedContent`'s `contentKey` lambda determines content identity across recompositions — a new `targetState` only triggers enter/exit animations if `contentKey(targetState) != contentKey(currentState)`. `DownloadingRemainingChapters` is a `data class`, so successive chapters (`currentlyDownloading` incrementing) produce structurally-different instances of the *same* Kotlin class. `contentKey = { it::class }` collapses all of those to one identity (`DownloadingRemainingChapters::class`), so `AnimatedContent` treats them as the same "slot" and just recomposes the existing composable in place — no crossfade/slide is triggered — while a genuine state-family change (e.g. `ConfirmChapters` → `DownloadingRemainingChapters`) still has a different `KClass` and does trigger the transition. This matches the one other consumer of `DownloadState` field updates in the codebase (`DownloadingRemainingChapters` composable itself just receives updated `currentlyDownloading`/`totalToDownloads` props and recomposes normally).

**Progress ring sweep**: `CircularProgressIndicator(progress = { animatedProgress })` now reads from an `animateFloatAsState` whose `targetValue` is the raw ratio and whose `animationSpec = tween(400)`. Compose animation semantics guarantee that when `targetValue` changes (each chapter increments `currentlyDownloading`), the state's `.value` interpolates from its previous value to the new target over 400ms on each recomposition frame, rather than snapping — this is the same mechanism used throughout Compose for animated progress (e.g. the M3 samples). Since the indicator reads `animatedProgress` (not `currentlyDownloading.toFloat() / totalToDownloads` directly), each chapter completion now produces a 400ms sweep instead of an instant jump.

## Verify-only items (no code changes)

- **Search fields** (`SearchStoryScreen.kt`): confirmed no `colors =` override on `TextField` or `SegmentedButton` — the only `colors =` in the file is on the informational `Card`, which is unrelated. M3's default focus/label-float and segmented-button check-icon animations apply as-is.
- **`RangeSlider`** (`DownloadScreen.kt`): confirmed no `startThumb =`/`endThumb =` composables are passed — the call uses only `value`/`onValueChange`/`valueRange`/`steps`, so M3's default thumb press/scale animations are intact.
- **Consolidate list rows** (`ConsolidateScreen.kt`): confirmed rows use `Modifier.clickable { ... }` (default ripple), not a custom `pointerInput`. Per the ticket, the optional empty-state entrance animation was skipped.

## Test plan

- [x] `./gradlew assembleDebug` — passes
- [x] `./gradlew test` — passes
- [ ] Manual device verification of `contentKey` and progress-ring sweep (flagged above, not possible in this environment)