### PR TITLE
Remove the Compose Material 2 dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '17'
-        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
     buildFeatures {
         compose true
@@ -111,7 +110,6 @@ dependencies {
     androidTestImplementation composeBom
 
     implementation libs.compose.ui
-    implementation libs.compose.material
     implementation libs.compose.material3
     implementation libs.compose.material.icons.core
     implementation libs.compose.material.icons.extended

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,6 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
-compose-material = { group = "androidx.compose.material", name = "material" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }


### PR DESCRIPTION
## Summary

Final ticket (redesign-13) in the M3 redesign series: removes the Compose Material **2** dependency now that every screen has migrated to M3. See [docs/tickets/redesign-13-remove-material2.md](docs/tickets/redesign-13-remove-material2.md) for the full ticket.

- Deleted `implementation libs.compose.material` from `app/build.gradle` and the `compose-material` entry from `gradle/libs.versions.toml`. Kept `compose-material-icons-core` / `compose-material-icons-extended` (separate artifacts, same Maven group).
- Removed the module-wide `freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"` compiler flag — unnecessary since Kotlin 1.6 for `@OptIn`-annotated call sites; `assembleDebug` and `test` both pass without it.
- `implementation libs.material` (Android Views Material Components, backing the XML/AppCompat theme) and `androidx.appcompat` were left untouched, per the ticket's explicit out-of-scope note — different artifacts entirely.

## Acceptance criteria

- [x] `grep -rn "androidx.compose.material\." app/src | grep -v "androidx.compose.material.icons"` returns nothing.
- [x] `grep -rn "ExperimentalMaterialApi" app/src` returns nothing.
- [x] `compose-material` appears in neither `gradle/libs.versions.toml` nor `app/build.gradle`; `compose-material-icons-core` and `compose-material-icons-extended` remain in both.
- [x] `./gradlew :app:dependencies --configuration debugRuntimeClasspath` shows no `androidx.compose.material:material:` line (the `material-ripple` transitive dep from material3 itself, and `material-icons-*` lines, are expected and present).
- [x] `./gradlew assembleDebug`, `./gradlew lint` and `./gradlew test` all pass.
- [ ] **Manual smoke test on a device/emulator — NOT performed, needs a human before merge.** No device/emulator was available in this environment. All three launcher tabs rendering and a full Confirm → Downloading → Success download flow should be verified manually before this PR (and the stack) merges. Given the risk profile of this ticket (removing a whole dependency), extra care was taken that `assembleDebug`/`lint`/`test` are all clean, but that's not a substitute for the on-device check.

## Note: this is the final ticket in the stack

This PR is the **last** of the redesign-00 → redesign-13 stacked-PR series for the M3 redesign. Once this PR and all of its ancestor PRs (redesign-00 through redesign-12) are reviewed and merged **bottom-up** (redesign-00 first, this one last), the Material 3 redesign is complete and the entire stack collapses into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)