### PR TITLE
Add JaCoco coverage reporting and a PR regression gate

### DIFF
--- a/.github/scripts/jacoco_line_coverage.py
+++ b/.github/scripts/jacoco_line_coverage.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Print the overall LINE coverage percentage from a JaCoco XML report."""
+import sys
+import xml.etree.ElementTree as ET
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: jacoco_line_coverage.py <jacoco-report.xml>", file=sys.stderr)
+        sys.exit(1)
+
+    report = ET.parse(sys.argv[1]).getroot()
+
+    # Report-level counters are the <counter> elements that are direct children of <report>,
+    # one per type, listed after every <package>. findall("counter") only matches those,
+    # not the per-package/per-class ones nested inside <package>/<class>/etc.
+    for counter in report.findall("counter"):
+        if counter.get("type") == "LINE":
+            covered = int(counter.get("covered"))
+            missed = int(counter.get("missed"))
+            total = covered + missed
+            percent = (covered / total * 100) if total else 100.0
+            print(f"{percent:.2f}")
+            return
+
+    print("no report-level LINE counter found", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,49 @@ jobs:
       - name: Lint
         run: bash ./gradlew lint --stacktrace
 
-      - name: Unit tests
-        run: bash ./gradlew test --stacktrace
+      - name: Unit tests & coverage report
+        run: bash ./gradlew test jacocoTestReport --stacktrace
+
+      - name: Restore main's coverage baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: coverage-baseline.txt
+          key: coverage-baseline-${{ github.sha }}
+          restore-keys: |
+            coverage-baseline-
+
+      - name: Check line coverage did not regress
+        if: github.event_name == 'pull_request'
+        run: |
+          PR_COVERAGE=$(python3 .github/scripts/jacoco_line_coverage.py app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml)
+          echo "PR line coverage: ${PR_COVERAGE}%"
+
+          if [ ! -f coverage-baseline.txt ]; then
+            echo "::warning::No cached coverage baseline found for main (cache missing or evicted) — skipping coverage regression check."
+            exit 0
+          fi
+
+          BASELINE=$(cat coverage-baseline.txt)
+          echo "main line coverage: ${BASELINE}%"
+          awk -v b="$BASELINE" -v p="$PR_COVERAGE" 'BEGIN {
+            if (p + 0 < b + 0) {
+              printf "::error::Line coverage decreased: %.2f%% (main) -> %.2f%% (PR)\n", b, p
+              exit 1
+            }
+            printf "Line coverage OK: %.2f%% (main) -> %.2f%% (PR)\n", b, p
+          }'
+
+      - name: Save coverage baseline for main
+        if: github.event_name == 'push'
+        run: python3 .github/scripts/jacoco_line_coverage.py app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml > coverage-baseline.txt
+
+      - name: Cache coverage baseline for main
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: coverage-baseline.txt
+          key: coverage-baseline-${{ github.sha }}
 
       - name: Upload lint report
         if: always()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.compose)
+    id 'jacoco'
 }
 
 // Release signing is machine-specific: the keystore and its credentials live outside version
@@ -133,4 +134,46 @@ dependencies {
 
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.test.espresso.core
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+// JVM unit test coverage only (testDebugUnitTest) — the Room DB tests that require a real
+// Android environment live in connectedAndroidTest and aren't covered here.
+tasks.register('jacocoTestReport', JacocoReport) {
+    dependsOn 'testDebugUnitTest'
+    group = 'verification'
+    description = 'Generates an HTML/XML JaCoco coverage report from the debug unit tests.'
+
+    reports {
+        xml.required = true
+        html.required = true
+    }
+
+    // Drop generated code (R/BuildConfig, Room's *_Impl DAOs/database, Compose's synthetic
+    // ComposableSingletons/LiveLiterals classes) so it doesn't dilute the coverage numbers.
+    def coverageExcludes = [
+            '**/R.class',
+            '**/R$*.class',
+            '**/BuildConfig.*',
+            '**/Manifest*.*',
+            'android/**/*.*',
+            '**/*_Impl.class',
+            '**/*_Impl$*.class',
+            '**/*ComposableSingletons*.*',
+            '**/*LiveLiterals*.*',
+    ]
+
+    def javaClasses = fileTree(layout.buildDirectory.dir('intermediates/javac/debug/compileDebugJavaWithJavac/classes')) {
+        exclude coverageExcludes
+    }
+    def kotlinClasses = fileTree(layout.buildDirectory.dir('tmp/kotlin-classes/debug')) {
+        exclude coverageExcludes
+    }
+
+    classDirectories.setFrom(files(javaClasses, kotlinClasses))
+    sourceDirectories.setFrom(files("$projectDir/src/main/java"))
+    executionData.setFrom(layout.buildDirectory.file('jacoco/testDebugUnitTest.exec'))
 }


### PR DESCRIPTION
## Summary
- Wires up the core Gradle `jacoco` plugin with a `jacocoTestReport` task (HTML/XML) over `testDebugUnitTest`, excluding generated code (Room `*_Impl`, Compose `ComposableSingletons`/`LiveLiterals`, `R`/`BuildConfig`/`Manifest`).
- CI now caches main's line-coverage % (keyed by commit sha) on every push to `main`, and PR builds compare their own coverage against the most recent cached baseline for the base branch, failing the check if coverage regresses.
- If no baseline cache is found (first run, or evicted after 7 days unused), the check skips with a warning instead of failing closed.

## Test plan
- [x] `./gradlew jacocoTestReport` runs locally and produces `app/build/reports/jacoco/jacocoTestReport/{html,jacocoTestReport.xml}` with generated code excluded from the numbers.
- [x] `.github/scripts/jacoco_line_coverage.py` verified against the generated report (extracts the report-level `LINE` counter correctly).
- [x] Comparison logic (awk) verified locally for both pass (baseline lower) and fail (baseline higher) cases.
- [ ] First CI run on `main` needs to land to actually seed the baseline cache — until then, PRs will warn-and-skip rather than gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)