### PR TITLE
Fix Gradle build warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.compose)
     id 'jacoco'
@@ -34,7 +33,7 @@ def gitCommitCount = {
 }()
 
 android {
-    namespace 'eu.monniot.resync'
+    namespace = 'eu.monniot.resync'
 
     signingConfigs {
         if (hasReleaseSigningConfig) {
@@ -64,19 +63,16 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig hasReleaseSigningConfig ? signingConfigs.release : signingConfigs.debug
+            signingConfig = hasReleaseSigningConfig ? signingConfigs.release : signingConfigs.debug
         }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
     buildFeatures {
-        compose true
-        buildConfig true
+        compose = true
+        buildConfig = true
     }
 
     testOptions {
@@ -88,7 +84,7 @@ android {
 
 repositories {
     maven {
-        url 'https://github.com/psiegman/mvn-repo/raw/master/releases'
+        url = 'https://github.com/psiegman/mvn-repo/raw/master/releases'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,13 +17,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,5 @@ androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espres
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
- Migrate off the `org.jetbrains.kotlin.android` plugin to AGP 9's built-in Kotlin support — root-caused via `-Pandroid.debug.obsoleteApi=true` as the actual source of the `applicationVariants`/`testVariants`/`unitTestVariants` obsolete-API warnings (not project code)
- Remove 8 `gradle.properties` overrides that were blanket-added by an earlier AGP upgrade assistant run to preserve old defaults the project never actually relies on (no `resValue` usage, `targetSdkVersion` already explicit, no `<uses-sdk>` in the manifest, `shrinkResources` never enabled, etc.) — one of these (`android.dependency.useConstraints`) was also the cause of the recurring "library constraints" performance warning
- Fix Groovy DSL space-assignment deprecations in `app/build.gradle` (`namespace`, `signingConfig`, `compose`, `buildConfig`, repo `url`), only visible with `--warning-mode all`
- Drop the now-unused `kotlin-android` entry from the version catalog

No warnings are suppressed — every fix addresses the underlying cause rather than hiding it.

## Test plan
- [x] `./gradlew clean assembleDebug lint test jacocoTestReport --warning-mode all` — builds clean with zero warnings/deprecations in the output
- [x] Compared Android Lint output before/after (`19 warnings` both times) to confirm no lint regressions from the config changes