### PR TITLE
Fix JaCoco coverage report after built-in Kotlin migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,9 @@ tasks.register('jacocoTestReport', JacocoReport) {
     def javaClasses = fileTree(layout.buildDirectory.dir('intermediates/javac/debug/compileDebugJavaWithJavac/classes')) {
         exclude coverageExcludes
     }
-    def kotlinClasses = fileTree(layout.buildDirectory.dir('tmp/kotlin-classes/debug')) {
+    // AGP's built-in Kotlin support (in use since the project dropped the kotlin.android
+    // plugin) compiles here instead of the old tmp/kotlin-classes/debug.
+    def kotlinClasses = fileTree(layout.buildDirectory.dir('intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes')) {
         exclude coverageExcludes
     }
 


### PR DESCRIPTION
## Summary
- ffb45d6 (#701) moved off the `kotlin.android` plugin onto AGP's built-in Kotlin support, which compiles Kotlin sources to `intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes` instead of `tmp/kotlin-classes/debug`.
- `jacocoTestReport`'s `classDirectories` still pointed at the old path, so it silently saw zero Kotlin classes: the report had no line counters at all, and `jacoco_line_coverage.py` errored out.
- This has been failing the "Save coverage baseline for main" CI step on every push since ffb45d6 landed.

## Test plan
- [x] `./gradlew testDebugUnitTest jacocoTestReport` succeeds and produces a report with real per-class line counters
- [x] `python3 .github/scripts/jacoco_line_coverage.py app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml` prints a coverage percentage instead of erroring
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)